### PR TITLE
Relax ActiveSupport dependency

### DIFF
--- a/activesupport-json_encoder.gemspec
+++ b/activesupport-json_encoder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir['test/**/*.rb']
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'activesupport', '>= 4.1.0', '< 5.0'
+  gem.add_dependency 'activesupport', '>= 4.1.0'
 
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Allow use of `activesupport-json_encoder` with Rails 5.
